### PR TITLE
160 serving orders should instantly removes them and not display them on a new fetch

### DIFF
--- a/src/Components/Buttons/Buttons.js
+++ b/src/Components/Buttons/Buttons.js
@@ -159,6 +159,7 @@ const GenericButton = ({
             console.error('An error occurred:', error.message);
         } finally {
             isServing(-1);
+            
         }
     };
 
@@ -166,8 +167,11 @@ const GenericButton = ({
         if (setConfig) {
             setConfig(prevConfig => ({ ...prevConfig, enable: !prevConfig.enable }));
         }
-        if (label === "SERVIE")
+        if (label === "SERVIE") {
             handleServed(currentOrderId);
+            navigationAfter();
+            navigationPrev();
+        }
 
         if (label === "SUIVANT")
             navigationAfter();

--- a/src/Components/OrdersDisplay/OrdersDisplay.js
+++ b/src/Components/OrdersDisplay/OrdersDisplay.js
@@ -136,7 +136,7 @@ function OrdersDisplay({ orderAnnoncement, selectOrder, setNbrOrder, activeRecal
 
         const orderToDisplay = [];
 
-        ordersData.forEach((order) => {
+        ordersData.filter((order) => order.id !== isServing).forEach((order) => {
           const foodPart = [];
           order.food_ordered.forEach((food) => {
             if (food.part === order.part) {
@@ -272,9 +272,10 @@ function OrdersDisplay({ orderAnnoncement, selectOrder, setNbrOrder, activeRecal
     const intervalId = setInterval(fetchOrders, 5000);
 
     return () => clearInterval(intervalId);
-  }, []);
+  }, [isServing]);
 
   useEffect(() => {
+    let nbrOrders = 0;
     const newOrdersLineComponents = ordersLine1.filter((order) => order.props.orderDetails.id !== isServing).map((order) => ({
       component: (
         <SingleOrderDisplay
@@ -290,6 +291,7 @@ function OrdersDisplay({ orderAnnoncement, selectOrder, setNbrOrder, activeRecal
     let array = [];
     newOrdersLineComponents.forEach((component) => { array.push(component.component); });
     setOrdersLine1(array);
+    nbrOrders += array.length;
     const newOrdersLineComponents2 = ordersLine2.filter((order) => order.props.orderDetails.id !== isServing).map((order) => ({
       component: (
         <SingleOrderDisplay
@@ -305,7 +307,9 @@ function OrdersDisplay({ orderAnnoncement, selectOrder, setNbrOrder, activeRecal
     array = [];
     newOrdersLineComponents2.forEach((component) => { array.push(component.component); });
     setOrdersLine2(array);
+    nbrOrders += array.length;
     selectOrderRef.current = selectOrder;
+    setNbrOrder(nbrOrders);
   }, [selectOrder, isServing]);
 
   useEffect(() => {
@@ -343,10 +347,6 @@ function OrdersDisplay({ orderAnnoncement, selectOrder, setNbrOrder, activeRecal
     prepareText(currentOrder);
   }, [selectOrder]);
 
-  useEffect(() => {
-    if (isServing !== -1)
-      setNbrOrders(nbrOrders - 1);
-  }, [isServing]);
 
   return (
     <div className="relative w-full h-full grid grid-rows-2 grid-cols-1">

--- a/src/Components/OrdersDisplay/OrdersDisplayPasse.js
+++ b/src/Components/OrdersDisplay/OrdersDisplayPasse.js
@@ -18,7 +18,7 @@ import OrderCarousel from './OrderCarousel';
  * @example
  * <OrdersDisplayPasse status="ready" selectOrder=0/>
  */
-function OrdersDisplayPasse({ status, selectOrder, setNbrOrder, onSelectOrderId, activeRecall, isServing, setOrdersForStatistics, orderAnnoncement, orderReading }) {
+function OrdersDisplayPasse({ status, selectOrder, setNbrOrder, onSelectOrderId, activeRecall, isServing }) {
   const navigate = useNavigate();
   const [nbrOrders, setNbrOrders] = useState(0);
   const [nbrOrdersWaiting, setNbrOrdersWaiting] = useState(0);
@@ -267,9 +267,6 @@ OrdersDisplayPasse.propTypes = {
   setNbrOrder: PropTypes.func,
   onSelectOrderId: PropTypes.func,
   activeRecall: PropTypes.bool,
-  setOrdersForStatistics: PropTypes.func,
-  orderAnnoncement: PropTypes.bool,
-  orderReading: PropTypes.bool,
   isServing: PropTypes.number,
 };
 

--- a/src/Components/OrdersDisplay/OrdersDisplayPasse.js
+++ b/src/Components/OrdersDisplay/OrdersDisplayPasse.js
@@ -18,7 +18,7 @@ import OrderCarousel from './OrderCarousel';
  * @example
  * <OrdersDisplayPasse status="ready" selectOrder=0/>
  */
-function OrdersDisplayPasse({ status, selectOrder, setNbrOrder, onSelectOrderId, activeRecall }) {
+function OrdersDisplayPasse({ status, selectOrder, setNbrOrder, onSelectOrderId, activeRecall, isServing, setOrdersForStatistics, orderAnnoncement, orderReading }) {
   const navigate = useNavigate();
   const [nbrOrders, setNbrOrders] = useState(0);
   const [nbrOrdersWaiting, setNbrOrdersWaiting] = useState(0);
@@ -90,7 +90,7 @@ function OrdersDisplayPasse({ status, selectOrder, setNbrOrder, onSelectOrderId,
 
         const orderToDisplay = [];
 
-        ordersData.forEach((order) => {
+        ordersData.filter((order) => order.id !== isServing).forEach((order) => {
           const foodPart = [];
           order.food_ordered.forEach((food) => {
             if (food.part === order.part) {
@@ -195,10 +195,10 @@ function OrdersDisplayPasse({ status, selectOrder, setNbrOrder, onSelectOrderId,
     const intervalId = setInterval(fetchOrders, 5000);
 
     return () => clearInterval(intervalId);
-  }, [status]);
+  }, [status, isServing]);
 
   useEffect(() => {
-    const newOrdersLineComponents = ordersLine1.map((order) => ({
+    const newOrdersLineComponents = ordersLine1.filter((order) => order.props.orderDetails.id !== isServing).map((order) => ({
       component: (
         <SingleOrderDisplay
           key={order.props.index}
@@ -213,8 +213,10 @@ function OrdersDisplayPasse({ status, selectOrder, setNbrOrder, onSelectOrderId,
     let array = [];
     newOrdersLineComponents.forEach((component) => { array.push(component.component); });
     setOrdersLine1(array);
+    if (setNbrOrder !== undefined)
+      setNbrOrder(array.length);
     selectOrderRef.current = selectOrder;
-  }, [selectOrder]);
+  }, [selectOrder, isServing]);
 
   useEffect(() => {
     const selectedOrder = ordersLine1[selectOrder];
@@ -265,6 +267,10 @@ OrdersDisplayPasse.propTypes = {
   setNbrOrder: PropTypes.func,
   onSelectOrderId: PropTypes.func,
   activeRecall: PropTypes.bool,
+  setOrdersForStatistics: PropTypes.func,
+  orderAnnoncement: PropTypes.bool,
+  orderReading: PropTypes.bool,
+  isServing: PropTypes.number,
 };
 
 export default OrdersDisplayPasse;


### PR DESCRIPTION
## Describe your changes
Removed order when clicking on Servie and add a filter to the fetched data to prevent being fetched while being served
## How to test the feature
Connect to the KDS and the POS
Make an order and send it
Serve it from the Kitchen and the Passe, it should now remove the order froom the list while serving it
## Issue ticket number and link
Closes #160 
## Checklist before requesting a review
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Documentation has been updated as required
If a single item in this checklist is not checked, the pull request cannot be accepted
